### PR TITLE
Move tide direction to the client

### DIFF
--- a/app/components/station-detail/index.js
+++ b/app/components/station-detail/index.js
@@ -69,7 +69,7 @@ export default class StationDetail extends Component {
   }
 
   render() {
-    const { tideChart, weather, city, tideTable, todaysTides, currentTideDirection, loading } = this.state
+    const { tideChart, weather, city, tideTable, todaysTides, loading } = this.state
 
     if (loading) {
       return (
@@ -84,9 +84,9 @@ export default class StationDetail extends Component {
       <ScrollView style={styles.container}>
         <TidePhrase
           style={styles.tidePhrase}
-          tideDirection={currentTideDirection}
           city={city}
           tides={tideTable}
+          todaysTides={todaysTides}
         />
 
         <WeatherRow weather={weather.currentWind} icon="wind" />

--- a/app/components/station-detail/remaining-tide-time.js
+++ b/app/components/station-detail/remaining-tide-time.js
@@ -10,7 +10,6 @@ import moment from 'moment'
 import findNextTide from '../../utils/find-next-tide'
 import BaseStyle from '../../base-styles'
 
-
 export default class RemainingTideTime extends Component {
   constructor(props) {
     super(props)

--- a/app/components/station-detail/tide-phrase.js
+++ b/app/components/station-detail/tide-phrase.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import {
   StyleSheet,
   View,
@@ -8,28 +8,43 @@ import {
 import BaseStyle from '../../base-styles'
 import TideDirectionArrow from '../tide-list/tide-direction-arrow'
 import RemainingTideTime from './remaining-tide-time'
+import findTideDirection from '../../utils/find-tide-direction'
 
-const TidePhrase = ({ city, tideDirection, tides }) => (
-  <View style={styles.container}>
-    <TideDirectionArrow
-      direction={tideDirection}
-      style={styles.arrow}
-      largeTideArrow
-    />
-    <View style={styles.tidePhrase}>
-      <View style={styles.tidePhraseRow}>
-        <Text style={[styles.loudHeader, styles.tideDirectionText]}>
-          {tideDirection}
-        </Text>
-        <Text style={[styles.loudHeader, styles.fadedPhraseText]}>Tide</Text>
+export default class TidePhrase extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      tideDirection: findTideDirection(props.todaysTides),
+    }
+  }
+
+  render() {
+    const { city, tides } = this.props
+    const { tideDirection } = this.state
+    return (
+      <View style={styles.container}>
+        <TideDirectionArrow
+          direction={tideDirection}
+          style={styles.arrow}
+          largeTideArrow
+        />
+        <View style={styles.tidePhrase}>
+          <View style={styles.tidePhraseRow}>
+            <Text style={[styles.loudHeader, styles.tideDirectionText]}>
+              {tideDirection}
+            </Text>
+            <Text style={[styles.loudHeader, styles.fadedPhraseText]}>Tide</Text>
+          </View>
+          <Text style={[styles.loudHeader, styles.fadedPhraseText]}>
+            in {city}
+          </Text>
+          <RemainingTideTime tides={tides} />
+        </View>
       </View>
-      <Text style={[styles.loudHeader, styles.fadedPhraseText]}>
-        in {city}
-      </Text>
-      <RemainingTideTime tides={tides} />
-    </View>
-  </View>
-)
+    )
+  }
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -57,5 +72,3 @@ const styles = StyleSheet.create({
     lineHeight: 60,
   },
 })
-
-export default TidePhrase

--- a/app/utils/find-tide-direction.js
+++ b/app/utils/find-tide-direction.js
@@ -1,0 +1,11 @@
+import _ from 'lodash'
+
+export default function findTideDirection(todaysTides) {
+  const futureTides = _.filter(todaysTides, tide => !tide.pastTide)
+
+  if (futureTides[0] === 'high') {
+    return _.upperFirst('incoming')
+  } else {
+    return _.upperFirst('outgoing')
+  }
+}


### PR DESCRIPTION
There were some odd inconsistencies depending on data. The tide direction was being sourced on the server and was mismatched from the client. 

Now all "next" and "current" tide data that is being display to the user is coming from the `todaysTide` key from the servers response.